### PR TITLE
Fixed getting type identifier when merge OBJECTS

### DIFF
--- a/cscs/Parser.cs
+++ b/cscs/Parser.cs
@@ -603,10 +603,7 @@ namespace SplitAndMerge
             }
             else if (leftCell.Type == Variable.VarType.OBJECT && rightCell.Type == Variable.VarType.OBJECT)
             {
-                //typeof(Parser).GetMethod("MergeObjects", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
-                //    .MakeGenericMethod(leftCell.ObjectType)
-                //    .Invoke(null, new object[] { leftCell, rightCell, script });
-                var convertedObject = Convert.ChangeType(leftCell.Object, leftCell.ObjectType);
+                dynamic convertedObject = leftCell.Object;
                 MergeObjects(leftCell, rightCell, script, convertedObject);
             }
             else


### PR DESCRIPTION
Здравствуйте Василий.

Ваше решение получение индификатора типа выглядит намного лучше, чем было у меня. Но оно не совсем работало для меня, поскольку  Convert.ChangeType возвращает object и typeof(T)  в  Merge Objects возвращало System.Object, из-за чего операции выполнялись неправильно. Я заменил строку с Convert.ChangeType на определение типа через dynamic и теперь для меня всё работает.

Для тестирования операций с объектами я использую тип [Vector](https://www.stvdev.pro/Vector.cs).
Для данного типа при выполнении следующего скрипта:
```
vector = Vector(1,1,1);
Log(vector);
vector = vector + Vector(1,1,1);
Log(vector);
vector = vector * Vector(4);
Log(vector);
vector = vector / Vector(2);
Log(vector);
Log(vector == Vector(4,4,4));
Log(vector != Vector(4,4,4));
Log(vector == Vector(1,1,1));

```
Будет характерен вывод:
```
(1,1,1)
(2,2,2)
(8,8,8)
(4,4,4)
1
0
0
```

В этом скрипте команда Log выводит строку, полученную выполнением ToString() от получаемого, в качестве аргумента, объекта.

Михаил