### PR TITLE
Added a comparison of custom classes by value

### DIFF
--- a/cscs/Functions.Flow.cs
+++ b/cscs/Functions.Flow.cs
@@ -655,6 +655,36 @@ namespace SplitAndMerge
                 }
                 return true;
             }
+
+            public bool ReferenceEquals(object obj)
+            {
+                return ReferenceEquals(obj, this);
+            }
+
+            public override bool Equals(object obj)
+            {
+
+                return obj is ClassInstance instance &&
+                       EqualityComparer<CSCSClass>.Default.Equals(m_cscsClass, instance.m_cscsClass) &&
+                       (m_properties.Count == instance.m_properties.Count) &&
+                       (m_properties.Count == instance.m_properties
+                       .Where(x => m_properties.ContainsKey(x.Key) && m_properties[x.Key].Equals(x.Value)).Count());
+            }
+
+            public static bool operator ==(ClassInstance instance1, ClassInstance instance2)
+            {
+                return (instance1 is null && instance2 is null)
+                    || ((!(instance1 is null || instance2 is null))
+                    && (instance1.Equals(instance2)
+                    || instance1.ReferenceEquals(instance2)));
+
+
+            }
+
+            public static bool operator !=(ClassInstance instance1, ClassInstance instance2)
+            {
+                return !(instance1 == instance2);
+            }
         }
     }
 


### PR DESCRIPTION
Приветствую, Василий.

Я изучил сравнение экземпляров классов созданных непосредственно через cscs и в текущем варианте оно работает так, как я и ожидал. 'stock1 == stock2' вернёт true только в том случае, если 'stock2 = stock1' поскольку только в этом случае переменные ссылаются на одну область памяти, что и является равенством по умолчанию для классов в C#.
Я доработал класс класса cscs, чтобы сравнение проводилось, в первую очередь, по значению. Думаю это может быть уместно для cscs, поскольку в нем нет понятия структуры, которая является значимым типом. А для определения, является ли переменные ссылкой на один и тот же объект можно обратиться к методу ReferenceEquals.

Михаил.