### PR TITLE
A bug with setting properties in nested instances of classes from methods of the parent class.

### DIFF
--- a/cscs/Functions.Flow.cs
+++ b/cscs/Functions.Flow.cs
@@ -2373,16 +2373,16 @@ namespace SplitAndMerge
                 return varValue.DeepClone();
             }
             string varName = m_name;
-            if (script.ClassInstance != null)
-            {
-                //varName = script.ClassInstance.InstanceName + "." + m_name;
-                varValue = script.ClassInstance.SetProperty(m_name, varValue).Result;
-                return varValue.DeepClone();
-            }
 
             int ind = varName.IndexOf('.');
             if (ind <= 0)
             {
+                if (script.ClassInstance != null)
+                {
+                    //varName = script.ClassInstance.InstanceName + "." + m_name;
+                    varValue = script.ClassInstance.SetProperty(m_name, varValue).Result;
+                    return varValue.DeepClone();
+                }
                 return null;
             }
 


### PR DESCRIPTION
Приветствую. Наткнулся на проблему на проблему с установкой свойства экземпляра класса, если он является свойством другого класса из методов этого другого класса.

Скрипт для рассмотрения проблемы:
```
class HumanInfo
{
    Name = "";
}

class Human
{
    Info = null;
    Human()
    {
        Info = new HumanInfo();
    }
    
    function SetName(n)
    {
        Info.Name = n;
    }
    
    function GetName()
    {
        return Info.Name;
    }
    
}

human = new Human();
human.SetName("Gennady");
print(human.GetName());

human.Info.Name = "Anton";
print(human.GetName());
```

Вывод до исправления
![image](https://github.com/vassilych/cscs/assets/59393934/043914b2-7b8a-4d50-afb1-fe4bde638d36)

Вывод после исправления
![image](https://github.com/vassilych/cscs/assets/59393934/315bc4ae-0ac5-44f8-bd03-8f8957765531)

