### PR TITLE
Fix implementation of the property setting fix & Fix assignment of properties to a function without arguments

### DIFF
--- a/cscs/Functions.Flow.cs
+++ b/cscs/Functions.Flow.cs
@@ -2409,7 +2409,7 @@ namespace SplitAndMerge
                 return varValue.DeepClone();
             }
 
-            ParserFunction existing = InterpreterInstance.GetVariable(name, script);
+            ParserFunction existing = InterpreterInstance.GetVariable(name, script, true);
             Variable baseValue = existing != null ? existing.GetValue(script) : new Variable(Variable.VarType.ARRAY);
             baseValue.SetProperty(prop, varValue, script, name);
 
@@ -2449,7 +2449,7 @@ namespace SplitAndMerge
                 return varValue.DeepClone();
             }
 
-            ParserFunction existing = InterpreterInstance.GetVariable(name, script);
+            ParserFunction existing = InterpreterInstance.GetVariable(name, script, true);
             Variable baseValue = existing != null ? await existing.GetValueAsync(script) : new Variable(Variable.VarType.ARRAY);
             await baseValue.SetPropertyAsync(prop, varValue, script, name);
 

--- a/cscs/Functions.Flow.cs
+++ b/cscs/Functions.Flow.cs
@@ -591,9 +591,22 @@ namespace SplitAndMerge
                 return sb.ToString();
             }
 
-            public Task<Variable> SetProperty(string name, Variable value)
+            public Task<Variable> SetProperty(string name, Variable value) => SetProperty(name, value, null);
+
+            public Task<Variable> SetProperty(string name, Variable value, ParsingScript script)
             {
                 var namelower = name.ToLower();
+
+                int ind = namelower.IndexOf(".");
+                if (ind >= 0)
+                {
+                    string property = namelower.Substring(0, ind);
+                    string subProperty = namelower.Substring(ind + 1);
+                    Variable propertyVariable = m_properties.ContainsKey(property) ? m_properties[property] : new Variable(Variable.VarType.ARRAY);
+                    propertyVariable.SetProperty(subProperty, value, script, property);
+                    return Task.FromResult(Variable.EmptyInstance);
+                }
+
                 m_properties[namelower] = value;
                 m_propSet.Add(name);
                 m_propSetLower.Add(namelower);
@@ -2373,16 +2386,16 @@ namespace SplitAndMerge
                 return varValue.DeepClone();
             }
             string varName = m_name;
+            if (script.ClassInstance != null)
+            {
+                //varName = script.ClassInstance.InstanceName + "." + m_name;
+                varValue = script.ClassInstance.SetProperty(m_name, varValue, script).Result;
+                return varValue.DeepClone();
+            }
 
             int ind = varName.IndexOf('.');
             if (ind <= 0)
             {
-                if (script.ClassInstance != null)
-                {
-                    //varName = script.ClassInstance.InstanceName + "." + m_name;
-                    varValue = script.ClassInstance.SetProperty(m_name, varValue).Result;
-                    return varValue.DeepClone();
-                }
                 return null;
             }
 
@@ -2416,7 +2429,7 @@ namespace SplitAndMerge
             if (script.ClassInstance != null)
             {
                 //varName = script.ClassInstance.InstanceName + "." + m_name;
-                await script.ClassInstance.SetProperty(m_name, varValue);
+                await script.ClassInstance.SetProperty(m_name, varValue, script);
                 return varValue.DeepClone();
             }
 


### PR DESCRIPTION
Приветствую.

5edf9095fe27da79755491b3adcd3b2c26d2b569
Обнаружил что моё предыдущее исправление могло вызывать исключения при некоторых обстоятельствах, в частности если свойство было переменной типа OBJECT. Изменил реализацию исправления.

378d6b6cb35d92f1820eaab732cb0707bd2c4094
Столкнулся с проблемой. В случае присвоения свойству объекта значения из функции без параметров родительский объект свойства затирался пустой переменной.

Скрипт для рассмотрения проблемы
```
class A
{
    Property = 25;
}

a = new A();

print(a);

a.NewProperty = pstime();

print(a);
```

Вывод до исправления
![Screenshot_3](https://github.com/vassilych/cscs/assets/59393934/a97ccfb0-4f0a-40ac-b808-de5408e6e5ba)

Вывод после исправления
![Screenshot_4](https://github.com/vassilych/cscs/assets/59393934/314b30d4-4eb0-4e80-b527-6e278a55067b)
